### PR TITLE
Pass back User ID for purposes of server-side receipt verification

### DIFF
--- a/src/com/soomla/store/billing/amazon/AmazonIabHelper.java
+++ b/src/com/soomla/store/billing/amazon/AmazonIabHelper.java
@@ -162,7 +162,7 @@ public class AmazonIabHelper extends IabHelper {
                         PurchasingService.notifyFulfillment(purchaseToken, FulfillmentResult.FULFILLED);
                         fulfilled = true;
 
-                        IabPurchase purchase = new IabPurchase(ITEM_TYPE_INAPP, sku, purchaseToken, response.getRequestId().toString(), 0);
+                        IabPurchase purchase = new IabPurchase(ITEM_TYPE_INAPP, sku, purchaseToken, response.getRequestId().toString(), 0, response.getUserData().getUserId());
                         purchase.setDeveloperPayload(AmazonIabHelper.this.mExtraData);
 
                         purchaseSucceeded(purchase);


### PR DESCRIPTION
I want to be able to do my own server-side receipt verification; this requires the Amazon User ID from the purchase. This patch captures this data and makes it available in the purchase event extras dictionary. It depends on soomla/android-store#52 and is used by soomla/unity3d-store#422

Note that I did not update AndroidStore.jar in this commit as I don't know what other commits might occur before this is merged, and it could result in a binary conflict. If you accept these pull requests, please rebuild and update AndroidStore.jar in this repo.